### PR TITLE
Feature/add gtest as submodule

### DIFF
--- a/.github/workflows/mac_os_latest.yml
+++ b/.github/workflows/mac_os_latest.yml
@@ -3,15 +3,10 @@ name: mac_os_latest
 on: [push]
 
 env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
 jobs:
   build:
-    # The CMake configure and build commands are platform agnostic and should work equally
-    # well on Windows or Mac.  You can convert this to a matrix build if you need
-    # cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
     strategy:
@@ -34,45 +29,31 @@ jobs:
       with:
           node-version: ${{ matrix.node }}
 
-    - name: Googletest installer
-      # You may pin to the exact commit or the version.
-      # uses: MarkusJx/googletest-installer@2dbed3d0a9dc19bebe3e36773185ab9c17664c8d
-      uses: MarkusJx/googletest-installer@v1.1
-
-    - name: Checkout repository and submodules
+    - name: Checkout Repository and Submodules
       uses: actions/checkout@v3
       with:
         submodules: recursive
 
-
     - name: Create Build Environment
-      # Some projects don't allow in-source building, so create a separate build directory
-      # We'll use this as our working directory for all subsequent commands
       run: cmake -E make_directory ${{runner.workspace}}/build
 
     - name: Configure CMake
-      if: matrix.config.os != 'windows-latest'
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
       working-directory: ${{runner.workspace}}/build
-      # Note the current convention is to use the -S and -B options here to specify source
-      # and build directories, but this is only available with CMake 3.13 and higher.
-      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
       run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPIL_ALL=1
 
-    - name: Build project
+    - name: Build Project
       working-directory: ${{runner.workspace}}/build
       shell: bash
       run: cmake --build . --config ${{ matrix.config.build_type }} --target all
 
-    - name: Test
+    - name: Run UnitTests
       working-directory: ${{runner.workspace}}/build
       run: GTEST_OUTPUT=xml:test-results/ GTEST_COLOR=1 ctest -V
 
-    - name: Upload artifacts
+    - name: Upload Artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: common_tools_lib_mac_os
+        name: common_tools_lib_mac_os_x64
         path: |
           ${{ runner.workspace }}/build/*.dylib
           ${{ runner.workspace }}/build/*.a

--- a/.github/workflows/mac_os_latest.yml
+++ b/.github/workflows/mac_os_latest.yml
@@ -35,7 +35,6 @@ jobs:
           node-version: ${{ matrix.node }}
 
     - name: install Dependencies Linux
-      if: matrix.config.os == 'ubuntu-latest'
       run: sudo apt-get install libgtest-dev
 
     - name: Googletest installer
@@ -43,7 +42,11 @@ jobs:
       # uses: MarkusJx/googletest-installer@2dbed3d0a9dc19bebe3e36773185ab9c17664c8d
       uses: MarkusJx/googletest-installer@v1.1
 
-    - uses: actions/checkout@v3
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory
@@ -66,7 +69,6 @@ jobs:
       run: cmake --build . --config ${{ matrix.config.build_type }} --target all
 
     - name: Test
-      if: matrix.config.os != 'windows-latest'
       working-directory: ${{runner.workspace}}/build
       run: GTEST_OUTPUT=xml:test-results/ GTEST_COLOR=1 ctest -V
 

--- a/.github/workflows/mac_os_latest.yml
+++ b/.github/workflows/mac_os_latest.yml
@@ -34,9 +34,6 @@ jobs:
       with:
           node-version: ${{ matrix.node }}
 
-    - name: install Dependencies Linux
-      run: sudo apt-get install libgtest-dev
-
     - name: Googletest installer
       # You may pin to the exact commit or the version.
       # uses: MarkusJx/googletest-installer@2dbed3d0a9dc19bebe3e36773185ab9c17664c8d

--- a/.github/workflows/ubuntu_latest.yml
+++ b/.github/workflows/ubuntu_latest.yml
@@ -34,8 +34,7 @@ jobs:
       with:
           node-version: ${{ matrix.node }}
 
-    - name: install Dependencies Linux
-      if: matrix.config.os == 'ubuntu-latest'
+    - name: install Dependencies
       run: sudo apt-get install libgtest-dev
 
     - name: Googletest installer
@@ -43,7 +42,10 @@ jobs:
       # uses: MarkusJx/googletest-installer@2dbed3d0a9dc19bebe3e36773185ab9c17664c8d
       uses: MarkusJx/googletest-installer@v1.1
 
-    - uses: actions/checkout@v3
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
 
     - name: Create Build Environment
       run: cmake -E make_directory ${{runner.workspace}}/build

--- a/.github/workflows/ubuntu_latest.yml
+++ b/.github/workflows/ubuntu_latest.yml
@@ -3,15 +3,10 @@ name: ubuntu_latest
 on: [push]
 
 env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
 jobs:
   build:
-    # The CMake configure and build commands are platform agnostic and should work equally
-    # well on Windows or Mac.  You can convert this to a matrix build if you need
-    # cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
     strategy:
@@ -34,15 +29,7 @@ jobs:
       with:
           node-version: ${{ matrix.node }}
 
-    - name: install Dependencies
-      run: sudo apt-get install libgtest-dev
-
-    - name: Googletest installer
-      # You may pin to the exact commit or the version.
-      # uses: MarkusJx/googletest-installer@2dbed3d0a9dc19bebe3e36773185ab9c17664c8d
-      uses: MarkusJx/googletest-installer@v1.1
-
-    - name: Checkout repository and submodules
+    - name: Checkout Repository and Submodules
       uses: actions/checkout@v3
       with:
         submodules: recursive
@@ -51,26 +38,22 @@ jobs:
       run: cmake -E make_directory ${{runner.workspace}}/build
 
     - name: Configure CMake
-      if: matrix.config.os != 'windows-latest'
       working-directory: ${{runner.workspace}}/build
-      # Note the current convention is to use the -S and -B options here to specify source
-      # and build directories, but this is only available with CMake 3.13 and higher.
-      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
       run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{matrix.config.build_type}} -DPIL_ALL=1
 
-    - name: Build project
+    - name: Build Project
       working-directory: ${{runner.workspace}}/build
       shell: bash
       run: cmake --build . --config ${{ matrix.config.build_type }} --target all
 
-    - name: Test
+    - name: Run UnitTests
       working-directory: ${{runner.workspace}}/build
       run: GTEST_OUTPUT=xml:test-results/ GTEST_COLOR=1 ctest -V
 
-    - name: Upload artifacts
+    - name: Upload Artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: common_tools_lib_ubuntu
+        name: common_tools_lib_ubuntu_x64
         path: |
           ${{ runner.workspace }}/build/*.so
           ${{ runner.workspace }}/build/*.a

--- a/.github/workflows/windows_latest.yml
+++ b/.github/workflows/windows_latest.yml
@@ -3,17 +3,12 @@ name: windows_latest
 on: [push]
 
 env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
   CC: gcc
   CXX: g++
 
 jobs:
   build:
-    # The CMake configure and build commands are platform agnostic and should work equally
-    # well on Windows or Mac.  You can convert this to a matrix build if you need
-    # cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
     strategy:
@@ -36,19 +31,13 @@ jobs:
       with:
           node-version: ${{ matrix.node }}
 
-    - name: Checkout repository and submodules
+    - name: Checkout Repository and Submodules
       uses: actions/checkout@v3
       with:
         submodules: recursive
 
     - name: Create Build Environment
-      # Some projects don't allow in-source building, so create a separate build directory
-      # We'll use this as our working directory for all subsequent commands
       run: cmake -E make_directory ${{runner.workspace}}/build
-
-    - name: Copy GTest
-      working-directory: ${{runner.workspace}}/common_tools_lib
-      run: cp ${{runner.workspace}}/build/lib* ${{runner.workspace}}/build
 
     - name: Copy Windows DLLs
       working-directory: ${{runner.workspace}}/common_tools_lib
@@ -56,28 +45,24 @@ jobs:
 
     - name: Configure CMake
       working-directory: ${{runner.workspace}}/build
-      # Note the current convention is to use the -S and -B options here to specify source
-      # and build directories, but this is only available with CMake 3.13 and higher.
-      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
       shell: pwsh
       run: cmake ../common_tools_lib -GNinja -DCMAKE_BUILD_TYPE=${{matrix.config.build_type}} -DPIL_ALL=1 -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
 
-    - name: Build project
+    - name: Build Project
       working-directory: ${{runner.workspace}}/build
       shell: pwsh
       run: cmake --build . --config ${{ matrix.config.build_type }} --target all
 
-    - name: Test
+    - name: Run UnitTests
       working-directory: ${{runner.workspace}}/build
       run: .\SocketUnitTest.exe GTEST_OUTPUT=xml:test-results/ GTEST_COLOR=1 ctest -V;
            .\ExceptionUnitTest.exe GTEST_OUTPUT=xml:test-results/ GTEST_COLOR=1 ctest -V;
            .\FileHandlingUnitTest.exe GTEST_OUTPUT=xml:test-results/ GTEST_COLOR=1 ctest -V
 
-
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: common_tools_lib_windows_mingw
+        name: common_tools_lib_windows_mingw_x64
         path: |
           ${{ runner.workspace }}/build/*.dll
           ${{ runner.workspace }}/build/*.exe

--- a/.github/workflows/windows_latest.yml
+++ b/.github/workflows/windows_latest.yml
@@ -36,22 +36,19 @@ jobs:
       with:
           node-version: ${{ matrix.node }}
 
-
-
-    - uses: actions/checkout@v3
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory
       # We'll use this as our working directory for all subsequent commands
       run: cmake -E make_directory ${{runner.workspace}}/build
 
-    - name: Install gtest
-      working-directory: ${{runner.workspace}}/common_tools_lib
-      run: ./build_gtest.bat
-
     - name: Copy GTest
       working-directory: ${{runner.workspace}}/common_tools_lib
-      run: cp googletest/build/lib/* ${{runner.workspace}}/build
+      run: cp ${{runner.workspace}}/build/lib* ${{runner.workspace}}/build
 
     - name: Copy Windows DLLs
       working-directory: ${{runner.workspace}}/common_tools_lib

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "googletest"]
+	path = googletest
+	url = https://github.com/google/googletest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,28 +182,8 @@ if (DEFINED PIL_STATIC)
 
 endif () # DEFINED STATIC
 
-if (DEFINED ENV{GITHUB_ACTIONS})
-
-    if (WIN32)
-        if(DEFINED GTEST_LINK_DIR)
-            link_directories(${GTEST_LINK_DIR})
-        else()
-            link_directories("googletest/build/lib")
-        endif()
-        if(DEFINED GTEST_INCLUDE_DIR)
-            include_directories(${GTEST_INCLUDE_DIR})
-        else()
-            include_directories("googletest/googletest/include")
-        endif()
-    endif ()
-endif ()
-
 if (PIL_UNIT_TESTING)
-    if(DEFINED APPLE)
-        include_directories("/usr/local/include")
-        link_directories("/usr/local/lib")
-    endif() # APPLE
-
+    add_subdirectory(googletest)
     enable_testing()
     include(GoogleTest)
 

--- a/build_gtest.bat
+++ b/build_gtest.bat
@@ -1,7 +1,0 @@
-git clone https://github.com/google/googletest
-cd googletest
-mkdir build
-cd build
-cmake .. -GNinja -DCMAKE_CXX_COMPILER=C:/ProgramData/chocolatey/bin/g++.exe -DCMAKE_C_COMPILER=C:/ProgramData/chocolatey/bin/gcc.exe
-ninja
-cd ../..


### PR DESCRIPTION
Problem: 
 - Avoid workaround of windows build script and manual copying of gtest on windows systems.
 - Make sure the same version of google test is used for each platform.
 
Changes: 
 - Add gtest as subdirectory and add subdirectory to CMakeList
 - Cleanup github workflows
 - Implement #23 