### PR TITLE
Fix/socket unit test

### DIFF
--- a/Additional/ctlib/SocketDefines.h
+++ b/Additional/ctlib/SocketDefines.h
@@ -68,9 +68,9 @@ struct PIL_SOCKET
     PIL_BOOL m_IsConnected;
     PIL_ErrorHandle m_ErrorHandle;
 
-    ThreadHandle *m_callbackThreadHandle;
+    ThreadHandle *m_ReceiveCallbackThreadHandle;
     ReceiveThreadCallbackArgC *m_callbackThreadArg;
-    PIL_BOOL m_callbackActive;
+    PIL_BOOL m_ReceiveCallback;
 
 } typedef PIL_SOCKET;
 

--- a/Communication/include/ctlib/Socket.h
+++ b/Communication/include/ctlib/Socket.h
@@ -58,11 +58,7 @@ PIL_ERROR_CODE PIL_SOCKET_RegisterReceiveCallbackFunction(PIL_SOCKET *socketRet,
                                                           void (*callback)(PIL_SOCKET* socket, uint8_t *buffer, uint32_t len,
                                                                     void *), void *additional);
 
-PIL_ERROR_CODE PIL_SOCKET_UnregisterCallbackFunction(PIL_SOCKET *socketRet);
-//#endif // PIL_THREADING
-
-
-
+PIL_ERROR_CODE PIL_SOCKET_UnregisterReceiveCallbackFunction(PIL_SOCKET *socketRet);
 
 /**
  * @}

--- a/Communication/include/ctlib/Socket.hpp
+++ b/Communication/include/ctlib/Socket.hpp
@@ -21,9 +21,29 @@ namespace PIL
     class Socket
     {
     public:
+
+        struct ReceiveCallbackArg {
+            explicit ReceiveCallbackArg(std::function<void(std::shared_ptr<PIL::Socket>&, std::string&)>& c): m_ReceiveCallback(c){
+            }
+            std::function<void(std::shared_ptr<PIL::Socket>&, std::string&)> &m_ReceiveCallback;
+            std::shared_ptr<PIL::Socket> m_Socket = {};
+        };
+
+        /**
+         * @brief Workaround to pass std::functions to C-acceptCallback function.
+         */
+        struct ThreadAcceptArg
+        {
+            /** Old C-threading function. */
+            AcceptThreadArgC argC = {};
+            /** Function pointer to C++ function returning PIL::Socket object. */
+            std::function<void(std::unique_ptr<PIL::Socket> &)> acceptCallback = {};
+        };
+
+        Socket();
         Socket(TransportProtocol transportProtocol, InternetProtocol internetProtocol, const std::string &address,
                int port, uint16_t timeoutInMS);
-        Socket(std::unique_ptr<PIL_SOCKET> socket, std::string &ip, uint16_t port);
+        Socket(std::shared_ptr<PIL_SOCKET> &socket, std::string &ip, uint16_t port);
         ~Socket();
 
         PIL_ERROR_CODE Bind(PIL_BOOL reuse);
@@ -44,35 +64,20 @@ namespace PIL
         PIL_ERROR_CODE Send(std::string &message);
         PIL_ERROR_CODE SendTo(std::string &destAddr, int port, uint8_t *buffer, int *bufferLen);
 
-        std::string GetSenderIP();
+        PIL_ERROR_CODE CreateServerSocket(std::function<void(std::unique_ptr<PIL::Socket>&)> &receiveCallback);
+        PIL_ERROR_CODE ConnectToServer(std::string &ipAddr, int destPort, std::function<void(std::shared_ptr<Socket>& , std::string &)> &receiveCallback);
+
+        PIL_ERROR_CODE RegisterReceiveCallbackFunction(ReceiveCallbackArg& additionalArg);
+        PIL_ERROR_CODE UnregisterAllCallbackFunctions();
+
+        std::string GetSenderIPAddress();
         PIL_ERROR_CODE GetInterfaceInfos(InterfaceInfoList *interfaceInfos);
         PIL_BOOL IsOpen();
         TransportProtocol GetTransportProtocol() const { return m_TransportProtocol; }
         InternetProtocol GetInternetProtocol() const { return m_InternetProtocol; }
-
-        PIL_ERROR_CODE CreateServerSocket(std::function<void(std::unique_ptr<PIL::Socket>&)> &receiveCallback);
-        PIL_ERROR_CODE ConnectToServer(std::string &ipAddr, int destPort, std::function<void(std::unique_ptr<Socket>& , std::string &)> &receiveCallback);
-
-
-        struct ReceiveCallbackArg {
-            explicit ReceiveCallbackArg(std::function<void(std::unique_ptr<PIL::Socket>&, std::string&)>& c): m_ReceiveCallback(c){
-            }
-            std::function<void(std::unique_ptr<PIL::Socket>&, std::string&)> &m_ReceiveCallback;
-            std::unique_ptr<PIL::Socket> m_Socket = {};
-        };
-
-        PIL_ERROR_CODE RegisterReceiveCallbackFunction(ReceiveCallbackArg& additionalArg);
-        PIL_ERROR_CODE UnregisterCallbackFunction();
-
-        /**
- * @brief Workaround to pass std::functions to C-acceptCallback function.
- */
-        struct ThreadAcceptArg {
-            /** Old C-threading function. */
-            AcceptThreadArgC argC = {};
-            /** Function pointer to C++ function returning PIL::Socket object. */
-            std::function<void(std::unique_ptr<PIL::Socket>&)> acceptCallback = {};
-        };
+        void setPort(uint16_t mPort);
+        void setIPAddress(const std::string &mIpAddress);
+        void setSocketHandle(const std::shared_ptr<PIL_SOCKET> &mCSocketHandle);
 
     private:
         uint16_t m_Port;
@@ -81,10 +86,12 @@ namespace PIL
         InternetProtocol m_InternetProtocol;
         uint16_t m_TimeoutInMS;
 
-        std::unique_ptr<PIL_SOCKET> m_CSocketHandle;
+
+        std::shared_ptr<PIL_SOCKET> m_CSocketHandle;
         std::vector<std::unique_ptr<PIL_SOCKET>> m_SocketList;
        // std::unique_ptr<ThreadAcceptArg> m_ThreadArg;
         std::unique_ptr<PIL::Threading<ThreadAcceptArg>> m_AcceptThread;
+        std::unique_ptr<ReceiveCallbackArg> m_ReceiveCallback;
         PIL_ERROR_CODE RegisterAcceptCallback(std::function<void(std::unique_ptr<PIL::Socket>&)> &f);
     };
 

--- a/UnitTesting/SocketUnitTest.cpp
+++ b/UnitTesting/SocketUnitTest.cpp
@@ -27,9 +27,10 @@ void ReceiveHandlerC(PIL_SOCKET *socket, uint8_t* buffer, uint32_t len, void*)
 }
 
 
-void ReceiveHandlerCPP(std::unique_ptr<PIL::Socket> &socket, std::string& buffer)
+void ReceiveHandlerCPP(std::shared_ptr<PIL::Socket> &socket, std::string& buffer)
 {
     strncpy(recvBuff, (char*)buffer.c_str(), buffer.length());
+    EXPECT_TRUE(strcmp(recvBuff, loram_ipsum.c_str()) == 0);
 }
 
 
@@ -88,8 +89,9 @@ TEST(SocketTest_CPP, SimpleSocketTest)
     EXPECT_EQ(ret, PIL_NO_ERROR);
     PIL::Socket clientSock(TCP, IPv4, "localhost", 14003, 1000);
     std::string destIP = "127.0.0.1";
-    std::function<void(std::unique_ptr<PIL::Socket>& , std::string &)> callbackFunc = ReceiveHandlerCPP;
+    std::function<void(std::shared_ptr<PIL::Socket>& , std::string &)> callbackFunc = ReceiveHandlerCPP;
     ret = clientSock.ConnectToServer(destIP, 14002, callbackFunc);
+    std::this_thread::sleep_for(std::chrono::microseconds(10000));
     EXPECT_EQ(ret, PIL_NO_ERROR);
 }
 


### PR DESCRIPTION
- Problem: 
   - Segmentation fault or PIL::Exceptions randomly occur when executing socket unit tests.
   - #32 
   - #28 

- Changes: 
    - Change names of callback functions
    - Copy C socket object when passing it to C++ callback to avoid double close execution
    - Fix SIGSEV caused by a casting error